### PR TITLE
feat: Add page numbering in footer

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -51,6 +51,14 @@
         #set text(8pt)
         979-8-3503-2934-6/23/\$31.00 ©2023 IEEE
       ]
+      else [
+        #set align(center)
+        #set text(10pt)
+        #counter(page).display(
+          "1/1",
+          both: true
+        )
+      ]
     }),
   )
 


### PR DESCRIPTION
:sparkles: Added page numbering to footer of pages starting from page 2

**Discussion**:
- Should page numbering start on page 1, or is the initial footer from the IEEE template wanted?