### PR TITLE
Ole/upgrade 0.13

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -57,32 +57,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725634671,
-        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -93,15 +77,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1725513492,
-        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {
@@ -176,11 +159,11 @@
     "typst-packages": {
       "flake": false,
       "locked": {
-        "lastModified": 1725788529,
-        "narHash": "sha256-5N9UmFJgBFcVZWJ8jyx5xHWiWou8a9KjwuhruQzJwG4=",
+        "lastModified": 1742571498,
+        "narHash": "sha256-0kzZ+pGImQzP+DkTdCaHs/BHSouWmaTwJnnhGoB3/dY=",
         "owner": "typst",
         "repo": "packages",
-        "rev": "9b0ffff0bb029f3c470c2f523a119c137671a756",
+        "rev": "d7cb4032b0e105504d5dc43a60220b132b3c83b7",
         "type": "github"
       },
       "original": {

--- a/template.typ
+++ b/template.typ
@@ -33,7 +33,11 @@
     margin: if paper-size == "a4" {
       (x: 41.5pt, top: 80.51pt, bottom: 89.51pt)
     } else {
-      (x: (50pt / 216mm) * 100%, top: (55pt / 279mm) * 100%, bottom: (64pt / 279mm) * 100%)
+      (
+        x: (50pt / 216mm) * 100%,
+        top: (55pt / 279mm) * 100%,
+        bottom: (64pt / 279mm) * 100%,
+      )
     },
     header: header,
     numbering: "1/1",
@@ -92,8 +96,9 @@
 
   // Configure headings.
   set heading(numbering: "I.A.1.")
-  show heading: it => locate(loc => {
+  show heading: it => {
     // Find out the final number of the heading counter.
+    let loc = it.location()
     let levels = counter(heading).at(loc)
     let deepest = if levels != () {
       levels.last()
@@ -105,7 +110,7 @@
     if it.level == 1 [
       // First-level headings are centered smallcaps.
       // We don't want to number of the acknowledgment section.
-      #let is-ack = it.body in ([Acknowledgment], [Acknowledgement])
+      #let is-ack = it.body in ([Acknowledgment], [Acknowledgment])
       #set align(center)
       #set text(if is-ack {
         10pt
@@ -139,7 +144,7 @@
       }
       _#(it.body):_
     ]
-  })
+  }
 
   // Display the assignments's title.
   v(3pt, weak: true)
@@ -151,9 +156,10 @@
     let end = calc.min((i + 1) * 4, authors.len())
     let is-last = authors.len() == end
     let slice = authors.slice(i * 4, end)
-    grid(columns: slice.len() * (
-        1fr,
-      ), gutter: 12pt, ..slice.map(author => align(
+    grid(columns: slice.len()
+        * (
+          1fr,
+        ), gutter: 12pt, ..slice.map(author => align(
         center,
         {
           text(12pt, author.name)
@@ -183,8 +189,7 @@
 
   // Start two column mode and configure paragraph properties.
   show: columns.with(2, gutter: 12pt)
-  set par(justify: true, first-line-indent: 1em)
-  show par: set block(spacing: 0.65em)
+  set par(justify: true, first-line-indent: 1em, spacing: 0.65em)
 
   // Display abstract and index terms.
   if abstract != none [


### PR DESCRIPTION
## Upgrade to the 0.13 typst compiler

This PR introduces some fixes for compatibility with the most recent typst compiler:

- Fix syntax for locating a heading element in its show rule (previously lead to compile _error_)
- Set paragraph spacing correctly

The nix flake was also updated to include the newest compiler in the dev shell.